### PR TITLE
Enable section names to have spaces

### DIFF
--- a/eg/mvp.ini
+++ b/eg/mvp.ini
@@ -11,3 +11,6 @@ z = -123 ; do stuff!
 
 [Foo::Bar / baz]
 x = 1
+
+[Foo::Bar / Bap Bop Boop]
+yarp = 1

--- a/lib/Config/MVP/Reader/INI.pm
+++ b/lib/Config/MVP/Reader/INI.pm
@@ -43,7 +43,7 @@ sub read_into_assembler {
   sub change_section {
     my ($self, $section) = @_;
 
-    my ($package, $name) = $section =~ m{\A\s*(?:([^/\s]+)\s*/\s*)?(\S+)\z};
+    my ($package, $name) = $section =~ m{\A\s*(?:([^/\s]+)\s*/\s*)?(.+)\z};
     $package = $name unless defined $package and length $package;
 
     Carp::croak qq{couldn't understand section header: "$_[1]"}

--- a/t/mvp.t
+++ b/t/mvp.t
@@ -12,7 +12,7 @@ my @section_names = $seq->section_names;
 
 is_deeply(
   \@section_names,
-  [ qw(_ Foo::Bar baz) ],
+  [ qw(_ Foo::Bar baz), 'Bap Bop Boop' ],
   "loaded the right names from sample config",
 );
 
@@ -38,6 +38,14 @@ is_deeply(
   $seq->section_named('baz')->payload,
   { x => 1 },
   'baz payload',
+);
+
+is($seq->section_named('Bap Bop Boop')->package, 'Foo::Bar', 'Bap Bop Boop package');
+
+is_deeply(
+  $seq->section_named('Bap Bop Boop')->payload,
+  { yarp => 1 },
+  'Bap Bop Boop payload',
 );
 
 done_testing;


### PR DESCRIPTION
In the case of Pod::Weaver::Section::Collect this allows section headings to contain spaces
