### PR TITLE
"use base" -> "use parent"

### DIFF
--- a/lib/Config/MVP/Reader/INI.pm
+++ b/lib/Config/MVP/Reader/INI.pm
@@ -29,7 +29,7 @@ sub read_into_assembler {
 {
   package
    Config::MVP::Reader::INI::INIReader;
-  use base 'Config::INI::Reader';
+  use parent 'Config::INI::Reader';
 
   sub new {
     my ($class, $assembler) = @_;


### PR DESCRIPTION
One more usage of "use base" removed.

This is part of my quest to improve Dist::Milla. miyagawa/Dist-Milla#24
